### PR TITLE
Enables configuration of animators on NavigationTransitionDelegate

### DIFF
--- a/EasyTransitions/Classes/Navigation/NavigationTransitionDelegate.swift
+++ b/EasyTransitions/Classes/Navigation/NavigationTransitionDelegate.swift
@@ -9,7 +9,7 @@ import Foundation
 
 open class NavigationTransitionDelegate: NSObject {
 
-    private var transitionAnimator: NavigationTransitionAnimator? = .none
+    private var animators = [UINavigationControllerOperation: NavigationTransitionAnimator]()
     private let interactiveController = TransitionInteractiveController()
     
     open func wire(viewController: UIViewController, with pan: Pan) {
@@ -19,24 +19,23 @@ open class NavigationTransitionDelegate: NSObject {
         }
     }
     
-    open func set(animator: NavigationTransitionAnimator?) {
-        transitionAnimator = animator
+    open func set(animator: NavigationTransitionAnimator,
+                  forOperation operation: UINavigationControllerOperation) {
+        animators[operation] = animator
+    }
+
+    open func removeAnimator(forOperation operation: UINavigationControllerOperation) {
+        animators.removeValue(forKey: operation)
     }
 }
 
 extension NavigationTransitionDelegate: UINavigationControllerDelegate {
     
     open func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationControllerOperation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        
-        // TODO: - Support operation configuration.
-//        if operation == .push {
-//            return nil
-//        }
-        
-        if let animator = transitionAnimator {
-            return NavigationTransitionConfigurator(transitionAnimator: animator)
+        guard let animator = animators[operation] else {
+            return nil
         }
-        return nil 
+        return NavigationTransitionConfigurator(transitionAnimator: animator)
     }
     
     open func navigationController(_ navigationController: UINavigationController, interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {

--- a/Example/EasyTransitions/ViewControllers/Gallery/GalleryTableViewController.swift
+++ b/Example/EasyTransitions/ViewControllers/Gallery/GalleryTableViewController.swift
@@ -46,7 +46,8 @@ class GalleryTableViewController: UITableViewController {
         showAnimator.auxAnimations = {
             return [self.animations(presenting: $0), viewController.animations(presenting: $0)].flatMap { $0 }
         }
-        navigationDelegate.set(animator: showAnimator)
+        navigationDelegate.set(animator: showAnimator, forOperation: .push)
+        navigationDelegate.set(animator: showAnimator, forOperation: .pop)
         navigationDelegate.wire(viewController: viewController,
                                 with: .regular(.fromLeft))
         navigationController?.pushViewController(viewController, animated: true)


### PR DESCRIPTION
Now we can now set different animators for `UINavigationControllerOperation's` `.pop`, `.push` and `.none`. This should be enough to define simple functionality as to push with a animator and dismiss with an other. You can also remove the animator from the delegate using the `removeAnimator(forOperation: _)` function. 