### PR TITLE
Interactive controller configurable transition start

### DIFF
--- a/EasyTransitions/Classes/Modal/ModalTransitionDelegate.swift
+++ b/EasyTransitions/Classes/Modal/ModalTransitionDelegate.swift
@@ -12,11 +12,14 @@ open class ModalTransitionDelegate: NSObject {
     private var animators = [ModalOperation: ModalTransitionAnimator]()
     private let interactiveController = TransitionInteractiveController()
     
-    open func wire(viewController: UIViewController, with pan: Pan) {
+    open func wire(viewController: UIViewController,
+                   with pan: Pan,
+                   beginWhen: @escaping (() -> Bool) = { return true }) {
         interactiveController.wireTo(viewController: viewController, with: pan)
         interactiveController.navigationAction = {
             viewController.dismiss(animated: true, completion: nil)
         }
+        interactiveController.shouldBeginTransition = beginWhen
     }
 
     open func set(animator: ModalTransitionAnimator, for operation: ModalOperation) {

--- a/EasyTransitions/Classes/Navigation/NavigationTransitionDelegate.swift
+++ b/EasyTransitions/Classes/Navigation/NavigationTransitionDelegate.swift
@@ -12,19 +12,22 @@ open class NavigationTransitionDelegate: NSObject {
     private var animators = [UINavigationControllerOperation: NavigationTransitionAnimator]()
     private let interactiveController = TransitionInteractiveController()
     
-    open func wire(viewController: UIViewController, with pan: Pan) {
+    open func wire(viewController: UIViewController,
+                   with pan: Pan,
+                   beginWhen: @escaping (() -> Bool) = { return true }) {
         interactiveController.wireTo(viewController: viewController, with: pan)
         interactiveController.navigationAction = {
             viewController.navigationController?.popViewController(animated: true)
         }
+        interactiveController.shouldBeginTransition = beginWhen
     }
     
     open func set(animator: NavigationTransitionAnimator,
-                  forOperation operation: UINavigationControllerOperation) {
+                  for operation: UINavigationControllerOperation) {
         animators[operation] = animator
     }
 
-    open func removeAnimator(forOperation operation: UINavigationControllerOperation) {
+    open func removeAnimator(for operation: UINavigationControllerOperation) {
         animators.removeValue(forKey: operation)
     }
 }

--- a/EasyTransitions/Classes/TransitionInteractiveController.swift
+++ b/EasyTransitions/Classes/TransitionInteractiveController.swift
@@ -30,6 +30,7 @@ open class TransitionInteractiveController: UIPercentDrivenInteractiveTransition
     open var navigationAction: (() -> Void) = {
         fatalError("Missing navigationAction (ex: navigation.dismiss) on TransitionInteractiveController")
     }
+    open var shouldBeginTransition: () -> Bool = { return true }
     
     deinit {
         if let gestureRecognizer = gestureRecognizer {
@@ -58,7 +59,7 @@ open class TransitionInteractiveController: UIPercentDrivenInteractiveTransition
         let panned = panGesture.percentagePanned()
         switch recognizer.state {
         case .began:
-            if panVelocity > 0 {
+            if panVelocity > 0 && shouldBeginTransition() {
                 interactionInProgress = true
                 navigationAction()
             }
@@ -85,6 +86,7 @@ open class TransitionInteractiveController: UIPercentDrivenInteractiveTransition
 extension TransitionInteractiveController: UIGestureRecognizerDelegate {
     
     open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return false
+        // TODO: - Handle shared gesture action. 
+        return true
     }
 }

--- a/Example/EasyTransitions/ViewControllers/Gallery/GalleryTableViewController.swift
+++ b/Example/EasyTransitions/ViewControllers/Gallery/GalleryTableViewController.swift
@@ -46,10 +46,12 @@ class GalleryTableViewController: UITableViewController {
         showAnimator.auxAnimations = {
             return [self.animations(presenting: $0), viewController.animations(presenting: $0)].flatMap { $0 }
         }
-        navigationDelegate.set(animator: showAnimator, forOperation: .push)
-        navigationDelegate.set(animator: showAnimator, forOperation: .pop)
+        navigationDelegate.set(animator: showAnimator, for: .push)
+        navigationDelegate.set(animator: showAnimator, for: .pop)
         navigationDelegate.wire(viewController: viewController,
-                                with: .regular(.fromLeft))
+                                with: .regular(.fromTop), beginWhen: {
+                                    return viewController.collectionView!.contentOffset.y < 0
+        })
         navigationController?.pushViewController(viewController, animated: true)
     }
     


### PR DESCRIPTION
This PR adds support to `InteractiveTransitionController` to configure if the transition should start when the user pans. This is most useful on `UIViewControllers` with `UIScrollViews` as we don't want transition and scrolling to overlap each other. 