### PR TITLE
Made the demo "universal"

### DIFF
--- a/EasyTransitions/Classes/Animators/AppStoreAnimator.swift
+++ b/EasyTransitions/Classes/Animators/AppStoreAnimator.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public class AppStoreAnimator: ModalTransitionAnimator {
     
-    private var initialFrame: CGRect
+    public var initialFrame: CGRect
     private var edgeLayoutConstraints: NSEdgeLayoutConstraints?
     private let blurView = UIVisualEffectView(effect: nil)
     
@@ -32,8 +32,13 @@ public class AppStoreAnimator: ModalTransitionAnimator {
             return
         }
         
-        blurView.frame = container.frame
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+        blurView.frame = container.bounds
         container.addSubview(blurView)
+        let blurConstraints = NSEdgeLayoutConstraints(view: blurView, container: container)
+        blurConstraints.toggleConstraints(true)
+        blurConstraints.constants(to: 0)
+
         
         modalView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(modalView)

--- a/EasyTransitions/Classes/Utilities/NSEdgeLayoutConstraints.swift
+++ b/EasyTransitions/Classes/Utilities/NSEdgeLayoutConstraints.swift
@@ -16,6 +16,10 @@ public final class NSEdgeLayoutConstraints {
     }
     
     // MARK: - Init
+    public convenience init(view: UIView, container: UIView) {
+        self.init(view: view, container: container, frame: .zero)
+    }
+
     public init(view: UIView, container: UIView, frame: CGRect) {
         top = view.topAnchor.constraint(equalTo: container.topAnchor, constant: frame.minY)
         left = view.leftAnchor.constraint(equalTo: container.leftAnchor, constant: frame.minX)

--- a/Example/EasyTransitions.xcodeproj/project.pbxproj
+++ b/Example/EasyTransitions.xcodeproj/project.pbxproj
@@ -708,6 +708,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -725,6 +726,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Example/EasyTransitions/Info.plist
+++ b/Example/EasyTransitions/Info.plist
@@ -28,12 +28,16 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/Example/EasyTransitions/ViewControllers/Today/TodayCollectionViewController.swift
+++ b/Example/EasyTransitions/ViewControllers/Today/TodayCollectionViewController.swift
@@ -9,19 +9,27 @@
 import UIKit
 import EasyTransitions
 
+struct AppStoreAnimatorInfo {
+    var animator: AppStoreAnimator
+    var index: IndexPath
+}
+
 class TodayCollectionViewController: UICollectionViewController {
 
     private var modalTransitionDelegate = ModalTransitionDelegate()
-    
+    private var animatorInfo: AppStoreAnimatorInfo?
+
     // MARK: - Init
     init() {
         let layout = UICollectionViewFlowLayout()
         layout.itemSize = CGSize(width: 335, height: 412)
         layout.minimumLineSpacing = 30
+        layout.minimumInteritemSpacing = 20
+        layout.sectionInset = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
         layout.scrollDirection = .vertical
         super.init(collectionViewLayout: layout)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -32,9 +40,30 @@ class TodayCollectionViewController: UICollectionViewController {
         collectionView?.register(TodayCollectionViewCell.self)
     }
 
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        let vcWidth = self.view.frame.size.width - 20//20 is left margin
+        var width: CGFloat = 355 //335 is ideal size + 20 of right margin for each item
+        let colums = round(vcWidth / width) //Aproximate times the ideal size fits the screen
+        width = (vcWidth / colums) - 20 //we substract the right marging
+        (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize = CGSize(width: width, height: 412)
+
+        //As the position of the cells might have changed, if we have an AppStoreAnimator, we update it's
+        //"initialFrame" so the dimisss animation still matches
+        if let animatorInfo = animatorInfo {
+            if let cell = collectionView?.cellForItem(at: animatorInfo.index) {
+                let cellFrame = view.convert(cell.frame, from: collectionView)
+                animatorInfo.animator.initialFrame = cellFrame
+            }
+            else {
+                //ups! the cell is not longer on the screen so… ¯\_(ツ)_/¯
+            }
+        }
+    }
+
     // MARK: - UICollectionViewDataSource
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
+        return 12
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -68,5 +97,6 @@ class TodayCollectionViewController: UICollectionViewController {
         detailViewController.modalPresentationStyle = .custom
         
         present(detailViewController, animated: true, completion: nil)
+        animatorInfo = AppStoreAnimatorInfo(animator: appStoreAnimator, index: indexPath)
     }
 }

--- a/Example/EasyTransitions/ViewControllers/Today/TodayCollectionViewController.swift
+++ b/Example/EasyTransitions/ViewControllers/Today/TodayCollectionViewController.swift
@@ -40,23 +40,35 @@ class TodayCollectionViewController: UICollectionViewController {
         collectionView?.register(TodayCollectionViewCell.self)
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        let vcWidth = size.width - 20//20 is left margin
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        recalculateItemSizes(givenWidth: self.view.frame.size.width)
+    }
+
+    func recalculateItemSizes(givenWidth width: CGFloat) {
+        let vcWidth = width - 20//20 is left margin
         var width: CGFloat = 355 //335 is ideal size + 20 of right margin for each item
         let colums = round(vcWidth / width) //Aproximate times the ideal size fits the screen
         width = (vcWidth / colums) - 20 //we substract the right marging
         (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize = CGSize(width: width, height: 412)
+    }
 
-        //As the position of the cells might have changed, if we have an AppStoreAnimator, we update it's
-        //"initialFrame" so the dimisss animation still matches
-        if let animatorInfo = animatorInfo {
-            if let cell = collectionView?.cellForItem(at: animatorInfo.index) {
-                let cellFrame = view.convert(cell.frame, from: collectionView)
-                animatorInfo.animator.initialFrame = cellFrame
-            }
-            else {
-                //ups! the cell is not longer on the screen so… ¯\_(ツ)_/¯
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        recalculateItemSizes(givenWidth: size.width)
+
+        coordinator.animate(alongsideTransition: nil) { (context) in
+            //As the position of the cells might have changed, if we have an AppStoreAnimator, we update it's
+            //"initialFrame" so the dimisss animation still matches
+            if let animatorInfo = self.animatorInfo {
+                if let cell = self.collectionView?.cellForItem(at: animatorInfo.index) {
+                    let cellFrame = self.view.convert(cell.frame, from: self.collectionView)
+                    animatorInfo.animator.initialFrame = cellFrame
+                }
+                else {
+                    //ups! the cell is not longer on the screen so… ¯\_(ツ)_/¯ lets move it out of the screen
+                    animatorInfo.animator.initialFrame = CGRect(x: (size.width-animatorInfo.animator.initialFrame.width)/2.0, y: size.height, width: animatorInfo.animator.initialFrame.width, height: animatorInfo.animator.initialFrame.height)
+                }
             }
         }
     }

--- a/Example/EasyTransitions/ViewControllers/Today/TodayCollectionViewController.swift
+++ b/Example/EasyTransitions/ViewControllers/Today/TodayCollectionViewController.swift
@@ -40,9 +40,9 @@ class TodayCollectionViewController: UICollectionViewController {
         collectionView?.register(TodayCollectionViewCell.self)
     }
 
-    override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
-        let vcWidth = self.view.frame.size.width - 20//20 is left margin
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        let vcWidth = size.width - 20//20 is left margin
         var width: CGFloat = 355 //335 is ideal size + 20 of right margin for each item
         let colums = round(vcWidth / width) //Aproximate times the ideal size fits the screen
         width = (vcWidth / colums) - 20 //we substract the right marging

--- a/Example/EasyTransitions/Views/CardView/CardView.swift
+++ b/Example/EasyTransitions/Views/CardView/CardView.swift
@@ -15,8 +15,7 @@ public final class CardView: UIView, NibOwnerLoadable {
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var closeButton: UIButton!
     @IBOutlet weak var iconTopLayoutConstraint: NSLayoutConstraint!
-    @IBOutlet weak var imageViewAspectRatio: NSLayoutConstraint!
-    
+
     // Delegate
     weak var delegate: CardViewDelegate?
     
@@ -24,27 +23,23 @@ public final class CardView: UIView, NibOwnerLoadable {
     public struct Layout {
         
         // MARK: - Properties
-        public let aspectRatio: CGFloat
         public let cornerRadius: CGFloat
         public let topOffset: CGFloat
         public let closeButtonAlpha: CGFloat
         
         // MARK: - Init
-        private init(aspectRatio: CGFloat, cornerRadius: CGFloat, topOffset: CGFloat, closeButtonAlpha: CGFloat) {
-            self.aspectRatio = aspectRatio
+        private init(cornerRadius: CGFloat, topOffset: CGFloat, closeButtonAlpha: CGFloat) {
             self.cornerRadius = cornerRadius
             self.topOffset = topOffset
             self.closeButtonAlpha = closeButtonAlpha
         }
         
         // MARK: - Layouts
-        public static let collapsed = Layout(aspectRatio: 335/412,
-                                             cornerRadius: 13,
+        public static let collapsed = Layout(cornerRadius: 13,
                                              topOffset: 20,
                                              closeButtonAlpha: 0)
         
-        public static let expanded = Layout(aspectRatio: 375/492,
-                                            cornerRadius: 0,
+        public static let expanded = Layout(cornerRadius: 0,
                                             topOffset: 20 + UIWindow.safeAreaTopInset,
                                             closeButtonAlpha: 1)
     }
@@ -72,9 +67,9 @@ public final class CardView: UIView, NibOwnerLoadable {
     }
     
     public func set(layout: CardView.Layout) {
-        imageView.layer.cornerRadius = layout.cornerRadius
+        self.layer.cornerRadius = layout.cornerRadius
+        self.layer.masksToBounds = true
         iconTopLayoutConstraint.constant = layout.topOffset
-        imageViewAspectRatio = imageViewAspectRatio.setMultiplier(multiplier: layout.aspectRatio)
         closeButton.alpha = layout.closeButtonAlpha
     }
     

--- a/Example/EasyTransitions/Views/CardView/CardView.xib
+++ b/Example/EasyTransitions/Views/CardView/CardView.xib
@@ -10,28 +10,24 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardView" customModule="Transitions_Example" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardView" customModule="EasyTransitions_Example" customModuleProvider="target">
             <connections>
                 <outlet property="closeButton" destination="uZt-Kn-9ZP" id="69b-Fs-A4i"/>
                 <outlet property="iconTopLayoutConstraint" destination="G9D-dy-J8n" id="FjZ-ug-0zp"/>
                 <outlet property="imageView" destination="xvq-cs-anC" id="9Fh-G9-xh9"/>
-                <outlet property="imageViewAspectRatio" destination="u4o-uX-a3h" id="Mea-Xl-NnS"/>
                 <outlet property="titleLabel" destination="qVo-t7-kmS" id="nV2-T6-DJF"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="335" height="412"/>
+        <view clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="402" height="427"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="xvq-cs-anC">
-                    <rect key="frame" x="0.0" y="0.0" width="335" height="412"/>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="xvq-cs-anC">
+                    <rect key="frame" x="0.0" y="-32.5" width="402" height="492"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="xvq-cs-anC" secondAttribute="height" multiplier="335:412" id="u4o-uX-a3h"/>
-                    </constraints>
                 </imageView>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="appIcon" translatesAutoresizingMaskIntoConstraints="NO" id="Nd4-Mq-DEh" customClass="iOSIconImageView" customModule="Transitions_Example" customModuleProvider="target">
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="appIcon" translatesAutoresizingMaskIntoConstraints="NO" id="Nd4-Mq-DEh" customClass="iOSIconImageView" customModule="EasyTransitions_Example" customModuleProvider="target">
                     <rect key="frame" x="20" y="20" width="87" height="87"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="87" id="Fqk-zw-PMQ"/>
@@ -39,7 +35,7 @@
                     </constraints>
                 </imageView>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Jxm-eh-x2d">
-                    <rect key="frame" x="20" y="358" width="182.5" height="34"/>
+                    <rect key="frame" x="20" y="382" width="182.5" height="34"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Design+Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lH3-By-JeI">
                             <rect key="frame" x="0.0" y="0.0" width="97.5" height="18"/>
@@ -55,8 +51,8 @@
                         </label>
                     </subviews>
                 </stackView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7mB-e3-KMG" customClass="RoundCornersButton" customModule="Transitions_Example" customModuleProvider="target">
-                    <rect key="frame" x="241" y="364" width="74" height="28"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7mB-e3-KMG" customClass="RoundCornersButton" customModule="EasyTransitions_Example" customModuleProvider="target">
+                    <rect key="frame" x="308" y="388" width="74" height="28"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="28" id="VT0-x0-c0h"/>
@@ -68,14 +64,14 @@
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APP OF THE DAY" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qVo-t7-kmS">
                     <rect key="frame" x="20" y="127" width="190" height="193.5"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="190" id="Ga8-jt-hA3"/>
+                        <constraint firstAttribute="width" priority="750" constant="190" id="Ga8-jt-hA3"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="54"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" alpha="0.0" contentMode="center" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uZt-Kn-9ZP">
-                    <rect key="frame" x="265" y="40" width="60" height="60"/>
+                    <rect key="frame" x="332" y="40" width="60" height="60"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="60" id="orU-oh-eoR"/>
                         <constraint firstAttribute="width" secondItem="uZt-Kn-9ZP" secondAttribute="height" multiplier="1:1" id="t2n-vu-NPF"/>
@@ -88,23 +84,26 @@
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="xvq-cs-anC" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="8ED-uA-xuF"/>
                 <constraint firstItem="qVo-t7-kmS" firstAttribute="leading" secondItem="Nd4-Mq-DEh" secondAttribute="leading" id="CUz-vn-rog"/>
                 <constraint firstItem="Nd4-Mq-DEh" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="G9D-dy-J8n"/>
-                <constraint firstAttribute="trailing" secondItem="xvq-cs-anC" secondAttribute="trailing" id="Kpp-Pt-R2f"/>
-                <constraint firstAttribute="leading" secondItem="xvq-cs-anC" secondAttribute="leading" id="LzM-eG-eAy"/>
-                <constraint firstItem="7mB-e3-KMG" firstAttribute="trailing" secondItem="xvq-cs-anC" secondAttribute="trailing" constant="-20" id="a2h-O3-0dz"/>
+                <constraint firstItem="xvq-cs-anC" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="trailing" id="Kpp-Pt-R2f"/>
+                <constraint firstItem="xvq-cs-anC" firstAttribute="leading" relation="lessThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" id="LzM-eG-eAy"/>
+                <constraint firstItem="xvq-cs-anC" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Yrh-zi-GMY"/>
+                <constraint firstItem="7mB-e3-KMG" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="-20" id="a2h-O3-0dz"/>
                 <constraint firstItem="uZt-Kn-9ZP" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="40" id="dBI-GM-fVf"/>
-                <constraint firstItem="7mB-e3-KMG" firstAttribute="bottom" secondItem="xvq-cs-anC" secondAttribute="bottom" constant="-20" id="dOl-QW-Sf1"/>
-                <constraint firstItem="xvq-cs-anC" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" id="ef2-eW-jJh"/>
-                <constraint firstItem="Nd4-Mq-DEh" firstAttribute="leading" secondItem="xvq-cs-anC" secondAttribute="leading" constant="20" id="hGF-VM-Bip"/>
+                <constraint firstItem="7mB-e3-KMG" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" constant="-11" id="dOl-QW-Sf1"/>
+                <constraint firstItem="xvq-cs-anC" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="bottom" id="ef2-eW-jJh"/>
+                <constraint firstItem="Nd4-Mq-DEh" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="hGF-VM-Bip"/>
                 <constraint firstItem="qVo-t7-kmS" firstAttribute="top" secondItem="Nd4-Mq-DEh" secondAttribute="bottom" constant="20" id="nKq-O3-rGs"/>
-                <constraint firstItem="Jxm-eh-x2d" firstAttribute="bottom" secondItem="xvq-cs-anC" secondAttribute="bottom" constant="-20" id="oVI-oH-XJf"/>
+                <constraint firstItem="Jxm-eh-x2d" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" constant="-11" id="oVI-oH-XJf"/>
+                <constraint firstItem="Jxm-eh-x2d" firstAttribute="top" relation="greaterThanOrEqual" secondItem="qVo-t7-kmS" secondAttribute="bottom" constant="6" id="rG1-SW-m8Z"/>
                 <constraint firstItem="Jxm-eh-x2d" firstAttribute="leading" secondItem="Nd4-Mq-DEh" secondAttribute="leading" id="tr3-RI-iMH"/>
-                <constraint firstItem="xvq-cs-anC" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="zRA-lX-kih"/>
+                <constraint firstItem="xvq-cs-anC" firstAttribute="top" relation="lessThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" id="zRA-lX-kih"/>
                 <constraint firstAttribute="trailing" secondItem="uZt-Kn-9ZP" secondAttribute="trailing" constant="10" id="zp6-hQ-kpT"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="33.5" y="-96"/>
+            <point key="canvasLocation" x="90" y="-97.5"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
- Modified `TodayCollectionViewController.swift` so it calculates the
sizes of the elements dynamically trying to match the ideal width 335,
on iPhones is 1 column portrait, 2 landscape on iPads is 3 and 4 or 4
and 5 depending the device. (Go ahead, try side by side apps on the
iPad, IT WORKS BABY!)
- Added an object to track the location of the cell if it changes due
to a screen rotation (or side by side apps resizing), otherwise during the “dismiss” it would animate
to the previous position and size and it wouldn’t match
- Changed the constraints in the card view so the image is centered and
upscaled (but never downscaled), as a result of this, the ratio
property is not longer necessary.
- Added constraints to keep the blur at the same size as the container,
otherwise presenting in one orientation and dismissing in a different
orientation or screen size (side by side apps) would result in the blur
not covering the entire screen.
- Added a new convenience initializer to
`NSEdgeLayoutConstraints.swift` but is not working as I hoped :(